### PR TITLE
feat: allow additional args to be passed

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,9 +1,10 @@
 package pgtest
 
 type PGConfig struct {
-	BinDir       string // Directory to look for postgresql binaries including initdb, postgres
-	Dir          string // Directory for storing database files, removed for non-persistent configs
-	IsPersistent bool   // Whether to make the current configuraton persistent or not
+	BinDir         string   // Directory to look for postgresql binaries including initdb, postgres
+	Dir            string   // Directory for storing database files, removed for non-persistent configs
+	IsPersistent   bool     // Whether to make the current configuraton persistent or not
+	AdditionalArgs []string // Additional arguments to pass to the postgres command
 }
 
 func New() *PGConfig {
@@ -31,6 +32,11 @@ func (c *PGConfig) UseBinariesIn(dir string) *PGConfig {
 
 func (c *PGConfig) DataDir(dir string) *PGConfig {
 	c.Dir = dir
+	return c
+}
+
+func (c *PGConfig) WithAdditionalArgs(args ...string) *PGConfig {
+	c.AdditionalArgs = args
 	return c
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -10,9 +10,10 @@ import (
 func TestPGConfig(t *testing.T) {
 	assert := assert.New(t)
 
-	config := pgtest.New().From("/usr/bin").DataDir("/tmp/data").Persistent()
+	config := pgtest.New().From("/usr/bin").DataDir("/tmp/data").Persistent().WithAdditionalArgs("-c", "log_statement=all")
 
 	assert.True(config.IsPersistent)
 	assert.EqualValues("/tmp/data", config.Dir)
 	assert.EqualValues("/usr/bin", config.BinDir)
+	assert.EqualValues([]string{"-c", "log_statement=all"}, config.AdditionalArgs)
 }

--- a/pgtest.go
+++ b/pgtest.go
@@ -153,11 +153,17 @@ func start(config *PGConfig) (*PG, error) {
 	}
 
 	// Start PostgreSQL
-	cmd := prepareCommand(isRoot, filepath.Join(binPath, "postgres"),
+	args := []string{
 		"-D", dataDir, // Data directory
 		"-k", sockDir, // Location for the UNIX socket
 		"-h", "", // Disable TCP listening
 		"-F", // No fsync, just go fast
+	}
+	if len(config.AdditionalArgs) > 0 {
+		args = append(args, config.AdditionalArgs...)
+	}
+	cmd := prepareCommand(isRoot, filepath.Join(binPath, "postgres"),
+		args...,
 	)
 	stderr, err := cmd.StderrPipe()
 	if err != nil {

--- a/pgtest_test.go
+++ b/pgtest_test.go
@@ -77,3 +77,22 @@ func TestPersistent(t *testing.T) {
 	err = pg.Stop()
 	assert.NoError(err)
 }
+
+func TestAdditionalArgs(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	pg, err := pgtest.New().WithAdditionalArgs("-c", "wal_level=logical").Start()
+	assert.NoError(err)
+	assert.NotNil(pg)
+
+	//Check if the wal_level is set to logical
+	var walLevel string
+	err = pg.DB.QueryRow("SHOW wal_level").Scan(&walLevel)
+	assert.NoError(err)
+	assert.Equal(walLevel, "logical")
+
+	err = pg.Stop()
+	assert.NoError(err)
+}


### PR DESCRIPTION
This PR allows additional arguments to be passed to the Postgres binary when it is called.

It adds:
 * `AdditionalArgs` field to `PGConfig` struct
 * Adds an `WithAdditionalArgs` function to the `PGConfig` struct to allow the addition of flags when using the builder pattern.
 * Adds 2 tests:
   * Test the arguments are added correctly to the struct when using `WithAdditionalArgs`
   * Test that the arguments are passed to the postgres and the config has taken affect 