### PR TITLE
Make more options overridable in `pgtest.PGConfig`

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ type PGConfig struct {
 	Dir            string   // Directory for storing database files, removed for non-persistent configs
 	IsPersistent   bool     // Whether to make the current configuraton persistent or not
 	AdditionalArgs []string // Additional arguments to pass to the postgres command
+	FSync          bool     // To set -F flag
 }
 
 func New() *PGConfig {
@@ -12,6 +13,7 @@ func New() *PGConfig {
 		BinDir:       "",
 		Dir:          "",
 		IsPersistent: false,
+		FSync:        false,
 	}
 }
 
@@ -37,6 +39,11 @@ func (c *PGConfig) DataDir(dir string) *PGConfig {
 
 func (c *PGConfig) WithAdditionalArgs(args ...string) *PGConfig {
 	c.AdditionalArgs = args
+	return c
+}
+
+func (c *PGConfig) EnableFSync() *PGConfig {
+	c.FSync = true
 	return c
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -3,7 +3,7 @@ package pgtest_test
 import (
 	"testing"
 
-	"github.com/Apollo-group-io/pgtest"
+	"github.com/rubenv/pgtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/config_test.go
+++ b/config_test.go
@@ -3,17 +3,18 @@ package pgtest_test
 import (
 	"testing"
 
-	"github.com/rubenv/pgtest"
+	"github.com/Apollo-group-io/pgtest"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPGConfig(t *testing.T) {
 	assert := assert.New(t)
 
-	config := pgtest.New().From("/usr/bin").DataDir("/tmp/data").Persistent().WithAdditionalArgs("-c", "log_statement=all")
+	config := pgtest.New().From("/usr/bin").DataDir("/tmp/data").Persistent().EnableFSync().WithAdditionalArgs("-c", "log_statement=all")
 
 	assert.True(config.IsPersistent)
 	assert.EqualValues("/tmp/data", config.Dir)
 	assert.EqualValues("/usr/bin", config.BinDir)
 	assert.EqualValues([]string{"-c", "log_statement=all"}, config.AdditionalArgs)
+	assert.EqualValues(true, config.FSync)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rubenv/pgtest
+module github.com/Apollo-group-io/pgtest
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Apollo-group-io/pgtest
+module github.com/rubenv/pgtest
 
 go 1.16
 

--- a/pgtest.go
+++ b/pgtest.go
@@ -157,8 +157,12 @@ func start(config *PGConfig) (*PG, error) {
 		"-D", dataDir, // Data directory
 		"-k", sockDir, // Location for the UNIX socket
 		"-h", "", // Disable TCP listening
-		"-F", // No fsync, just go fast
 	}
+
+	if config.FSync == false {
+		args = append(args, "-F")
+	}
+
 	if len(config.AdditionalArgs) > 0 {
 		args = append(args, config.AdditionalArgs...)
 	}

--- a/pgtest_test.go
+++ b/pgtest_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/rubenv/pgtest"
+	"github.com/Apollo-group-io/pgtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pgtest_test.go
+++ b/pgtest_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Apollo-group-io/pgtest"
+	"github.com/rubenv/pgtest"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Hi @rubenv 

Thanks allot for the amazing library, you might find this cool - maybe slightly concerning 🤣 - but we're using `pgtest` to spin up temporary databases on the network, to provide quick databases for testing purposes.

tl;dr we simply pipe TCP connections to unix sockets for `pgtest` instances spun up in real-time.

But we can't do this unless we have predefined passwords/dbnames set (security, its on the network!). And in some instances - for longer running/multi-phase usecases - we need to disable Fsync.

So I've added options to the `pgtest.PGConfig` config builder, which are used by the core `start` method to tailor for specific cases.

I have added tests that make sure this works.

Raising this PR in hopes that it unlocks more use-cases for this work of art. 

Thanks a ton!


